### PR TITLE
Need to support concurrent addMark and insert

### DIFF
--- a/test/micromerge.ts
+++ b/test/micromerge.ts
@@ -587,6 +587,81 @@ describe("Micromerge", () => {
         )
     })
 
+    it("correctly handles an addMark boundary that is a tombstone", () => {
+        const [doc1, doc2] = generateDocs("The *Peritext* editor")
+
+        // In doc1, we format "*Peritext*" as bold and then delete the asterisks
+        const { change: change1 } = doc1.change([
+            {
+                path: ["text"],
+                action: "addMark",
+                start: 4,
+                end: 13,
+                markType: "strong",
+            },
+            {
+                path: ["text"],
+                action: "delete",
+                index: 4,
+                count: 1,
+            },
+            {
+                path: ["text"],
+                action: "delete",
+                index: 12,
+                count: 1,
+            },
+        ])
+
+        // Concurrently, in doc2, we add underscores inside of the asterisks
+        // so that the text reads "The *_Peritext_* editor"
+        const { change: change2 } = doc2.change([
+            {
+                path: ["text"],
+                action: "insert",
+                index: 5,
+                values: ["_"],
+            },
+            {
+                path: ["text"],
+                action: "insert",
+                index: 14,
+                values: ["_"],
+            },
+        ])
+
+        // Apply the concurrent changes to the respective other document
+        doc2.applyChange(change1)
+        doc1.applyChange(change2)
+
+        // Both sides should end up with the same text
+        assert.deepStrictEqual(
+            doc1.root.text,
+            "The _Peritext_ editor".split(""),
+        )
+        assert.deepStrictEqual(
+            doc2.root.text,
+            "The _Peritext_ editor".split(""),
+        )
+
+        // The underscores should be bold, because the bold span ran from asterisk
+        // to asterisk, and the underscores were inside of the asterisks
+        const expectedTextWithFormatting = [
+            { marks: {}, text: "The " },
+            { marks: { strong: { active: true } }, text: "_Peritext_" },
+            { marks: {}, text: " editor" },
+        ]
+
+        assert.deepStrictEqual(
+            doc1.getTextWithFormatting(["text"]),
+            expectedTextWithFormatting,
+        )
+        assert.deepStrictEqual(
+            doc2.getTextWithFormatting(["text"]),
+            expectedTextWithFormatting,
+        )
+    })
+
     describe("comments", () => {
         it("returns a single comment in the flattened spans", () => {
             const [doc1] = generateDocs()


### PR DESCRIPTION
Here's a failing test demonstrating a bug. One user inserts some characters into a text, while concurrently another user bolds a span. The document that first applies the addMark and then the insertion does not get correctly updated, and after merging the two documents become permanently inconsistent.

This case is particularly tricky when the insertions occur exactly at the boundaries of where the concurrent addMark operation begins and ends. In the example in the test, doc1 is first in the state

```js
[
  { text: "The ", marks: {} },
  { text: "Peritext", marks: { strong: { active: true } } },
  { text: " editor", marks: {} },
]
```

Concurrently to the bolding of `Peritext`, doc2 inserted asterisks before and after the word `Peritext`. The merged result should then be:

```js
[
  { text: "The *", marks: {} },
  { text: "Peritext", marks: { strong: { active: true } } },
  { text: "* editor", marks: {} },
]
```

because that's what doc2 ends up with (since the bolding operation starts at the `P` of Peritext and ends on the second `t` of Peritext, and thus the asterisks are not part of the bolded span). This design also embeds the assumption that when you type at the boundary of a bold span, the bold span does not get extended (this is a question we discussed early on in the project and I'm not sure how you decided to handle it in the end).

Note that when inserting the first asterisk into the formatting spans, we need to decide whether it is appended to `"The "` or prepended to `"Peritext"` (the correct answer is the former); when inserting the second asterisk, we need to decide whether it is appended to `"Peritext"` or prepended to `" editor"` (the correct answer is the latter). This means that the correct insertion position depends on whether the boundary between spans is the beginning of a span or the end of a span!

Another fun case is demonstrated by the second failing test. Here doc1 is first in the state

```js
[
  { text: "The ", marks: {} },
  { text: "Peritext", marks: { strong: { active: true } } },
  { text: " editor", marks: { em: { active: true } } },
]
```

Concurrently to the bolding and italicising, doc2 inserted the text `"[1]"` (think: footnote) right at the boundary between the bold span and the italic span. Since the inserted text falls within neither span, it cannot be appended or prepended to either of the existing spans, but it needs to be given a span of its own, which is neither bold nor italic:

```js
[
  { text: "The ", marks: {} },
  { text: "Peritext", marks: { strong: { active: true } } },
  { text: "[1]", marks: {} },
  { text: " editor", marks: { em: { active: true } } },
]
```

Let's discuss how to handle this when Geoffrey is back. I fear we will have to change the data structure a bit to track additional metadata that's required in order to determine how to correctly process insertions.