### PR TITLE
fix for running the demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
                 </div>
             </div>
         </div>
-        <script src="src/index.ts" type="module"></script>
+        <script src="src/index.ts"></script>
     </body>
 </html>


### PR DESCRIPTION
Parcel has some [misunderstandings between script tags declared as es module](https://github.com/parcel-bundler/parcel/issues/1401) and it's cascading into the build as console errors #22  #21 

Removing the attribute sorts this out. until they fix it in Parcel.