### PR TITLE
feat: add serialization (save/load)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "peritext",
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
@@ -29,6 +28,7 @@
                 "prosemirror-transform": "^1.3.3",
                 "prosemirror-view": "1.18.7",
                 "shuffle-seed": "^1.1.6",
+                "sializer": "^0.2.0",
                 "ts-mocha": "^8.0.0",
                 "uuid": "^3.4.0"
             },
@@ -2765,7 +2765,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2995,7 +2994,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5432,7 +5430,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8852,6 +8849,15 @@
                 "seedrandom": "^2.4.2"
             }
         },
+        "node_modules/sializer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/sializer/-/sializer-0.2.0.tgz",
+            "integrity": "sha512-GUc4IFhycUCd8xzlo/7Jci0fu1KMDNu05CTjigVv07svKAeLRQrV+wlmO4gHEyTHcIm7vCc3rwy4S1Yi5dSz+w==",
+            "dependencies": {
+                "buffer": "^5.6.0",
+                "utfz-lib": "^0.2.0"
+            }
+        },
         "node_modules/side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -9677,6 +9683,11 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
             "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
             "dev": true
+        },
+        "node_modules/utfz-lib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/utfz-lib/-/utfz-lib-0.2.0.tgz",
+            "integrity": "sha512-wQhMpAJhwFesoBEkGg44GsDL4Hi09tXvSWLIwh5HKXZkSN1Tc30ZlDH24DEoISz+fKoJTsLjcwd2zM6lAhXQvA=="
         },
         "node_modules/util": {
             "version": "0.12.4",
@@ -12063,8 +12074,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -12259,7 +12269,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -14139,8 +14148,7 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "iferr": {
             "version": "1.0.2",
@@ -16713,6 +16721,15 @@
                 "seedrandom": "^2.4.2"
             }
         },
+        "sializer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/sializer/-/sializer-0.2.0.tgz",
+            "integrity": "sha512-GUc4IFhycUCd8xzlo/7Jci0fu1KMDNu05CTjigVv07svKAeLRQrV+wlmO4gHEyTHcIm7vCc3rwy4S1Yi5dSz+w==",
+            "requires": {
+                "buffer": "^5.6.0",
+                "utfz-lib": "^0.2.0"
+            }
+        },
         "side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -17357,6 +17374,11 @@
                     "dev": true
                 }
             }
+        },
+        "utfz-lib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/utfz-lib/-/utfz-lib-0.2.0.tgz",
+            "integrity": "sha512-wQhMpAJhwFesoBEkGg44GsDL4Hi09tXvSWLIwh5HKXZkSN1Tc30ZlDH24DEoISz+fKoJTsLjcwd2zM6lAhXQvA=="
         },
         "util": {
             "version": "0.12.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "prosemirror-transform": "^1.3.3",
         "prosemirror-view": "1.18.7",
         "shuffle-seed": "^1.1.6",
+        "sializer": "^0.2.0",
         "ts-mocha": "^8.0.0",
         "uuid": "^3.4.0"
     },

--- a/test/micromerge.ts
+++ b/test/micromerge.ts
@@ -5,6 +5,7 @@ import type { RootDoc } from "../src/bridge"
 import { inspect } from "util"
 import { generateDocs } from "./generateDocs"
 import { accumulatePatches } from "./accumulatePatches"
+import Micromerge from '../src/micromerge';
 
 const defaultText = "The Peritext editor"
 const textChars = defaultText.split("")
@@ -47,7 +48,9 @@ const testConcurrentWrites = (args: TraceSpec): void => {
     const { initialText = "The Peritext editor", preOps, inputOps1 = [], inputOps2 = [], expectedResult } = args
 
     const { docs, patches } = generateDocs(initialText)
-    const [doc1, doc2] = docs
+    let [doc1, doc2] = docs
+    doc1 = Micromerge.load(doc1.save())
+    doc2 = Micromerge.load(doc2.save())
     let [patchesForDoc1, patchesForDoc2] = patches
 
     if (preOps) {
@@ -1413,6 +1416,18 @@ describe.only("Micromerge", () => {
             const currentIndex = doc1.resolveCursor(cursor)
 
             assert.deepStrictEqual(currentIndex, 0)
+        })
+
+
+        it("de/re-serializes ", () => {
+            const { docs } = generateDocs()
+            const [doc1, doc2] = docs
+
+            let binary = doc1.save()
+            let copy = Micromerge.load(binary)
+
+            assert.deepStrictEqual(copy.getRoot(), doc1.getRoot())
+
         })
     })
 })


### PR DESCRIPTION
This adds serialization to micromerge.

```js
let binary = doc.save()
let copy = Micromerge.load(binary)
```

I had to remove the `Symbol` definitions because they were not serializing correctly. An alternative approach we can take, if you really do need Symbols,  is to use `symbol.description`: https://sequoia.makes.software/two-painful-ways-to-misuse-javascripts-symbol-descriptions/, but that would have taken more work so I punted on it. Tests pass without using `Symbol` anyway.